### PR TITLE
Fix type hints 

### DIFF
--- a/worlds/simpsonshitnrun/Rules.py
+++ b/worlds/simpsonshitnrun/Rules.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional
 from worlds.generic.Rules import set_rule, add_rule
 from .Regions import regionMap
@@ -12,7 +14,7 @@ import re
 import math
 
 if TYPE_CHECKING:
-    from . import ManualWorld
+    from . import SimpsonsHitAndRunWorld
 
 def infix_to_postfix(expr, location):
     prec = {"&": 2, "|": 2, "!": 3}
@@ -67,7 +69,7 @@ def evaluate_postfix(expr: str, location: str) -> bool:
         raise KeyError("Invalid logic format for location/region {}.".format(location))
     return stack.pop()
 
-def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
+def set_rules(world: SimpsonsHitAndRunWorld, multiworld: MultiWorld, player: int):
     # this is only called when the area (think, location or region) has a "requires" field that is a string
     def checkRequireStringForArea(state: CollectionState, area: dict):
         requires_list = area["requires"]
@@ -273,15 +275,15 @@ def set_rules(world: "ManualWorld", multiworld: MultiWorld, player: int):
     # Victory requirement
     multiworld.completion_condition[player] = lambda state: state.has("__Victory__", player)
 
-def YamlEnabled(world: "ManualWorld", multiworld: MultiWorld, state: CollectionState, player: int, param: str) -> bool:
+def YamlEnabled(world: SimpsonsHitAndRunWorld, multiworld: MultiWorld, state: CollectionState, player: int, param: str) -> bool:
     """Is a yaml option enabled?"""
     return is_option_enabled(multiworld, player, param)
 
-def YamlDisabled(world: "ManualWorld", multiworld: MultiWorld, state: CollectionState, player: int, param: str) -> bool:
+def YamlDisabled(world: SimpsonsHitAndRunWorld, multiworld: MultiWorld, state: CollectionState, player: int, param: str) -> bool:
     """Is a yaml option disabled?"""
     return not is_option_enabled(multiworld, player, param)
 
-def YamlCompare(world: "ManualWorld", multiworld: MultiWorld, state: CollectionState, player: int, args: str, skipCache: bool = False) -> bool:
+def YamlCompare(world: SimpsonsHitAndRunWorld, multiworld: MultiWorld, state: CollectionState, player: int, args: str, skipCache: bool = False) -> bool:
     """Is a yaml option's value compared using {comparator} to the requested value
     \nFormat it like {YamlCompare(OptionName==value)}
     \nWhere == can be any of the following: ==, !=, >=, <=, <, >


### PR DESCRIPTION
replaces the ManualWorld type hints with SimpsonsHitAndRunWorld (and gets rid of the string typing)