### PR TITLE
Simpsons Hit and Run: fix WebHost compatibility by assigning web attribute

### DIFF
--- a/worlds/simpsonshitnrun/world.py
+++ b/worlds/simpsonshitnrun/world.py
@@ -11,6 +11,7 @@ from .items import car_name_to_internal_id, ITEM_DEFS
 from .components import SHARSettings
 from .options import SimpsonsHitNRunOptions
 from .SHARContainer import gen
+from .web_world import SimpsonsHitNRunWebWorld
 
 class SimpsonsHitNRunWorld(World):
     """A 2003 Action Adventure game similar to the GTA series starring the Simpsons"""
@@ -30,6 +31,8 @@ class SimpsonsHitNRunWorld(World):
     car_name_to_internal_id = items.car_name_to_internal_id
 
     origin_region_name = "Hub"
+
+    web = SimpsonsHitNRunWebWorld()
 
     @staticmethod
     def interpret_slot_data(slot_data: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## What is this fixing or adding?

When installed on a self-hosted Archipelago WebHost, the game fails to load at startup:
```
Following worlds not loaded as they are invalid for WebHost: {'Simpsons Hit and Run'}
```

The WebHost requires every world to have a `web` attribute with a `tutorials` field. `web_world.py` already defines `SimpsonsHitNRunWebWorld(WebWorld)` with `tutorials` properly set, but it is never assigned on `SimpsonsHitNRunWorld`. The fix imports `SimpsonsHitNRunWebWorld` and assigns it as `web` on the world class.

## How was this tested?

Installed the apworld on a self-hosted Archipelago 0.6.7 WebHost instance. Before the fix, the game was excluded at startup with the error above. After the fix, the game loads correctly and can be generated and hosted.

## Screenshots 

<img width="732" height="533" alt="image" src="https://github.com/user-attachments/assets/5ccade10-c28b-44b2-88d4-2508ae2d0170" />

<img width="1034" height="780" alt="image" src="https://github.com/user-attachments/assets/2740c12e-9b3f-486c-b7f0-9da85531139d" />

<img width="664" height="163" alt="image" src="https://github.com/user-attachments/assets/62655142-6a0f-4c47-bda2-182563a0fcb8" />
